### PR TITLE
Fix font awesome stylus dependency breaking BC rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "chalk": "^1.0.0",
     "eslint": "^0.22.1",
     "eslint-plugin-react": "^2.4.0",
-    "font-awesome-stylus": "^4.3.0",
+    "font-awesome-stylus": "4.7.0",
     "gulp": "^3.8.9",
     "gulp-concat": "^2.4.1",
     "gulp-cssmin": "^0.1.6",


### PR DESCRIPTION
Fixing the `font-awesome-stylus` dependency to `4.7.0` since `4.7.1` introduced a breaking change (see https://github.com/raulghm/Font-Awesome-Stylus/issues/35) which is breaking the asset compilation:

```
——————————————————————————————————————————
 ▄▄▄ ▄ ▄ ▄ ▄ ▄▄▄ ▄▄  ▄▄▄ ▄▄   ▄▄▄ ▄▄▄ ▄ ▄
  █  █▀█ █▄█ █▀█ ███ █▄█ █▀█   █  █▄█  █
——————————————————————————————————————————
[10:42:15] Starting 'js:dev'...
[10:42:15] Starting 'styles'...
[10:42:15] Starting 'fonts'...
[10:42:16] gulp-notify: [Compile Error] src/styles/thumbor-toy.styl:12:10
    8|  */
    9| @import './../../node_modules/normalize-css/normalize.css'
   10|
   11| $fa-font-path = 'fonts'
   12| @require './../../node_modules/font-awesome-stylus/stylus/index.styl'
----------------^
   13|
   14| placeholder()
   15|   &::-webkit-input-placeholder

failed to locate @require file ./../../node_modules/font-awesome-stylus/stylus/index.styl

[10:42:16] Finished 'styles' after 122 ms
events.js:160
      throw er; // Unhandled 'error' event
```